### PR TITLE
Added detection of input IDL file type. Fixed crash if output directo…

### DIFF
--- a/src/generator/compiler.cc
+++ b/src/generator/compiler.cc
@@ -21,24 +21,28 @@
 #include <unistd.h>
 #endif
 #include "generator.h"
+#include <fstream>
+
+/* LQ - prototype to determine if the file type is thrift */
+bool isThrift(char* filename);
 
 int main(int argc, const char *argv[])
 {
-	if (argc != 4)
-	{
-		fprintf(stderr, "Usage:\n\t%s protobuf proto_file output_dir\n"
-				"\t%s thrift thrift_file output_dir\n", argv[0], argv[0]);
+	/* LQ - update to use 2 command line arguments */
+	/* TODO: use optarg/getopt_long to have index-independent arguments? */
+	/* 	 Ex: srpc_generator -i <IDL_FILE> -o <OUTPUT_DIR> or */
+	/*  	     srpc_generator --input <IDL_FILE> --output <OUTPUT_DIR> */
+	if(argc != 3) {
+		fprintf(stderr, "Usage:\n\t%s <idl_file> <output_dir>\n", argv[0]);
 		return 0;
 	}
-
 	char *idl = const_cast<char *>(argv[1]);
-	bool is_thrift = (strcasecmp(idl, "thrift") == 0);
-	const char *idl_file = argv[2];
+	bool is_thrift = isThrift(idl);
+	const char *idl_file = argv[1];
 	struct GeneratorParams params;
 	Generator gen(is_thrift);
-//	Generate(file, parameter, generator_context, error);
 
-	params.out_dir = argv[3];
+	params.out_dir = argv[2];
 
 	char file_name[DIRECTORY_LENGTH] = { 0 };
 	size_t pos = 0;
@@ -59,4 +63,37 @@ int main(int argc, const char *argv[])
 	gen.generate(file_name, params);
 	fprintf(stdout, "[Generator Done]\n");
 	return 0;
+}
+
+/* LQ - function to determine if the input file is thrift or not */
+/* Date: 28 JAN 2022 */
+/* Description: Opens a file, reads the lines and checks for "syntax = proto", */
+/* 		which indicates a protobuf file. If it does not find this string, */
+/* 		return true and assume the file is thrift. Error out if file is unable to be read */
+/* Notes/TODO:  * Add enum to handle file types? (TYPE_THRIFT, TYPE_PROTOBUF, TYPE_UNKNOWN) */
+/*		* Better detection of file types? Better behaviour if thrift files have a specific format to look for */
+/*		* Handle error case when user provides a file that is not thrift nor protobuf */
+bool isThrift(char* filename) {
+
+	std::ifstream idl_file;
+	std::string line;
+	idl_file.open(filename);
+
+	if(idl_file.is_open()) {
+		while(!idl_file.eof()) {
+			getline(idl_file, line);
+			/* If the line contains "syntax = proto", it is a protobuf file */
+			if(line.find("syntax = proto") != std::string::npos) {
+				idl_file.close();
+				return false;
+			}	
+		}
+		idl_file.close();
+	} else {
+		/* Error case */
+		fprintf(stderr, "Unable to open IDL file: %s\n", filename);
+		exit(0);
+	}
+	/* Otherwise, return true (assume thrift format) */
+	return true;
 }

--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -95,12 +95,24 @@ bool Generator::generate(const std::string& idl_file, struct GeneratorParams par
 
 bool Generator::generate_header(idl_info& cur_info, struct GeneratorParams params)
 {
+	struct stat info;
+
 	for (auto& sub_info : cur_info.include_list)
 	{
 		fprintf(stdout, "[Generator] auto generate include file [%s]\n",
 				sub_info.absolute_file_path.c_str());
 		if (!this->generate_header(sub_info, params))
 			return false;
+	}
+
+	/* LQ - check if the output directory exists, if it does not error out */
+	/* Fixes a segfault (SIGSEG) crash if the output directory doesn't exist */
+	if(stat(params.out_dir, &info) != 0) {
+		fprintf(stderr, "[Generator Error] ouptut directory does not exist! Check the path?\n");
+		return false;
+	} else if((info.st_mode & S_IFDIR) == 0) {
+		fprintf(stderr, "[Generator Error] output directory path is not a directory! Check the path?\n");
+		return false;
 	}
 
 	// for protobuf: if no [rpc], don`t need to generate xxx.srpc.h

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -25,6 +25,7 @@
 #include <list>
 #include <string>
 #include <algorithm>
+#include <sys/stat.h>
 
 #include "printer.h"
 #include "parser.h"


### PR DESCRIPTION
This PR addresses two things I found in sprc_generator:
(1) Some redundancy in specifying the input IDL file type
(2) Crash if output directory doesn't exist

Currently, srpc_generator requires an argument for the IDL type. This PR is a starting point to automatically detect the file type without requiring the user to specify. It checks for "syntax = proto", a known string near the top of all protobuf IDL files. If there is more time, a better solution would be to use getopt_long or optargs to have position-independent command line arguments.

Also, the code assumes that the output directory exists. However, it will crash (segfault) if the output directory isn't valid. This PR also adds code to check for the existence of the output directory. Perhaps a further improvement could be made to create the output directory for the user in this case, should the directory not exist?

Feel free to reject or modify the changes - this was just a starting point based on my experience running the application.